### PR TITLE
add cario_kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@
   projects written in Cairo by OpenZeppelin
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI
 - [argent-x](https://github.com/argentlabs/argent-x) - Browser extension wallet
+- [cairo_kernel](https://github.com/ankitchiplunkar/cairo-jupyter) - Jupyter
+  kernel for Cairo.
 
 #### Utility
 


### PR DESCRIPTION
Jupyter notebook support for Cairo. If it would make more sense to create a new subcategory for `Jupyter` within Editor Plugins, happy to move it there.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
