### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ Please ensure your pull request adheres to the following guidelines:
 ---
 
 **Working on your first Pull Request?** You can learn how from this free series
-[How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).


### PR DESCRIPTION
Thanks for the work on this repo, Giorgo! While shamelessly copying it to another awesome list, I found out the howto link in CONTRIBUTING has moved under a different path so fixing it here.