### PR TITLE
Add starknet-rs library

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - [starknet.js](https://github.com/seanjameshan/starknet.js) - Javascript
   library
 - [starknet.py](https://github.com/software-mansion/starknet.py) - Python library
+- [starknet-rs](https://github.com/xJonathanLEI/starknet-rs) - Rust library
 - [starknet-hardhat-plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) -
   A plugin for integrating Starknet tools into Hardhat projects
 - [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts) -


### PR DESCRIPTION
I created a StarkNet library in Rust. It's meant to achieve at least functional parity with `starknet.js` and `starknet.py`.

The version currently [published](https://crates.io/crates/starknet) to crates.io offers full sequencer API coverage.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
