### PR TITLE
Add VS Code extension for code assistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@
 
 - [Cairo VS Code](https://www.cairo-lang.org/docs/quickstart.html#visual-studio-code-setup) -
   VS Code syntax support for Cairo (requires manual installation)
+- [Cairo language support](https://marketplace.visualstudio.com/items?itemName=ericglau.cairo-ls) -
+  Code assistance and compile error highlighting in VS Code.
 
 ---
 


### PR DESCRIPTION
Adds the following VS code extension for code assistance and compile error highlighting:  https://marketplace.visualstudio.com/items?itemName=ericglau.cairo-ls

(This can be used along with StarkWare's Cairo VS Code)

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
