### PR TITLE
Add briq in the list of projects built / deployed on StarkNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
   Deep Neural Net PoC
 - [argent-contracts-starknet](https://github.com/argentlabs/argent-contracts-starknet) -
   [Argent](https://www.argent.xyz/)'s Account contracts
+- [briq](https://github.com/briqNFT/briq-protocol) - NFT building & composability protocol
 
 #### Templates
 


### PR DESCRIPTION
I've added the [briq](https://briq.construction/) repo in the list of projects `Built / Deployed on StarkNet`.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
