### PR TITLE
Add starknet-react library

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@
   OpenZeppelin Contracts written in Cairo
 - [cairomate](https://github.com/a5f9t4/cairomate) - Structured, dependable legos for Starknet development. 
 - [caigo](https://github.com/dontpanicdao/caigo) - Golang Library.
+- [starknet-react](https://github.com/auclantis/starknet-react) - React hooks library.
 
 ## Tools
 


### PR DESCRIPTION
I added the React hooks library for StarkNet that I released the other day.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
