### PR TITLE
Add ecosystem category and starknet-ecosystem.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 - [Resources](#resources)
   - [Official](#official)
+  - [Ecosystem](#ecosystem)
   - [Tutorials](#tutorials)
   - [Articles](#articles)
   - [Security](#security)
@@ -71,6 +72,11 @@
 - [StarkNet Voting Workshop](https://starkware.notion.site/starkware/StarkNet-Voting-Workshop-b61ef5f4a62d45af86892cba3158f7e6) -
   End to end tutorial on building a voting app
 - [YouTube channel](https://www.youtube.com/channel/UCnDWguR8mE2oDBsjhQkgbvg/playlists) - Official StarkWare YouTube channel.
+
+#### Ecosystem
+
+- [StarkNet Ecosystem](https://starknet-ecosystem.com) -
+  A [community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
 
 #### Tutorials
 


### PR DESCRIPTION
- Create a dedicated Ecosystem category that will list every channel that provide informations about the ecosystem of StarkNet such as teams and projects building on it.
- Add starknet-ecosystem.com initiative

[Please describe your pull request here]

## Checklist

- [ X] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [ X] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [X ] Drop all `A` / `An` prefixes at the start of the description.
- [ X] Avoid using the word `StarkNet` in the description.
