### PR TITLE
Add protostar

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [juno](https://github.com/NethermindEth/juno) - Client (GoLang).
 - [nile](https://github.com/OpenZeppelin/nile) - CLI tool to develop StarkNet
   projects written in Cairo by OpenZeppelin
+- [protostar](https://docs.swmansion.com/protostar/) - CLI tool for developing and testing contracts in Cairo.
 - [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet) - Local
   testnet
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI


### PR DESCRIPTION
[Protostar](https://docs.swmansion.com/protostar/) allows user to:
- manage dependencies,
- compiling contracts,
- testing Cairo code in Cairo (including cheatcodes).

More features are planned (like dramatic test speed improvements). Protostar doesn't require python to run.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
