### PR TITLE
Add Starklings Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
   A [community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
 
 #### Tutorials
-- [Interactive Tutorial for Learning StarkNet](https://github.com/onlydustxyz/starklings) - An interactive tutorial to get you up and running with Starknet.
+- [Interactive Tutorials for StarkNet Development](https://github.com/onlydustxyz/starklings) - Interactive tutorials teaching all the different concepts in Cairo from beginner to advanced.
 - [Full-Stack StarkNet](https://github.com/sambarnes/fullstack-starknet) - Tutorials introducing a little bit of everything in a DApp.
 - [Unit Testing in StarkNet](https://perama-v.github.io/cairo/examples/unit_test/) -
   Using [`pytest`](https://docs.pytest.org/en/6.2.x/) to test contracts

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
   A [community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
 
 #### Tutorials
-
+- [Interactive Tutorial for Learning StarkNet](https://github.com/onlydustxyz/starklings) - An interactive tutorial to get you up and running with Starknet.
 - [Full-Stack StarkNet](https://github.com/sambarnes/fullstack-starknet) - Tutorials introducing a little bit of everything in a DApp.
 - [Unit Testing in StarkNet](https://perama-v.github.io/cairo/examples/unit_test/) -
   Using [`pytest`](https://docs.pytest.org/en/6.2.x/) to test contracts

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@
   A [community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
 
 #### Tutorials
-- [Interactive Tutorials for StarkNet Development](https://github.com/onlydustxyz/starklings) - Interactive tutorials teaching all the different concepts in Cairo from beginner to advanced.
 - [Full-Stack StarkNet](https://github.com/sambarnes/fullstack-starknet) - Tutorials introducing a little bit of everything in a DApp.
+- [Interactive Tutorials for StarkNet Development](https://github.com/onlydustxyz/starklings) - Interactive tutorials teaching all the different concepts in Cairo from beginner to advanced.
 - [Unit Testing in StarkNet](https://perama-v.github.io/cairo/examples/unit_test/) -
   Using [`pytest`](https://docs.pytest.org/en/6.2.x/) to test contracts
 - [Managing StarkNet deployments using Nile ⛵️✨](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)


### PR DESCRIPTION
Add Starklings interactive cairo development tutorials: https://github.com/onlydustxyz/starklings.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
