### PR TITLE
add get-starknet

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
   library
 - [starknet.py](https://github.com/software-mansion/starknet.py) - Python library
 - [starknet-rs](https://github.com/xJonathanLEI/starknet-rs) - Rust library
+- [get-staknet](https://github.com/starknet-community-libs/get-starknet) - StarkNet wallet <-> dApp bridge
 - [starknet-hardhat-plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) -
   A plugin for integrating Starknet tools into Hardhat projects
 - [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts) -


### PR DESCRIPTION
StarkNet wallet <-> dApp bridge

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
