### PR TITLE
add ape-starknet ape-cairo

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI
 - [voyager](https://voyager.online) - Block explorer.
 - [starktx](https://starktx.info/) - StarkTx Transaction Decoder.
+- [ape-cairo](https://github.com/ApeWorX/ape-cairo) - A compiler plugin for ape for the Cairo-lang
+- [ape-starknet](https://github.com/ApeWorX/ape-starknet) - An ape plugin for the StarkNet networks
 
 #### Utility
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI
 - [voyager](https://voyager.online) - Block explorer.
 - [starktx](https://starktx.info/) - StarkTx Transaction Decoder.
-- [ape-cairo](https://github.com/ApeWorX/ape-cairo) - A compiler plugin for ape for the Cairo-lang
-- [ape-starknet](https://github.com/ApeWorX/ape-starknet) - An ape plugin for the StarkNet networks
+- [ape-cairo](https://github.com/ApeWorX/ape-cairo) - Compiler plugin for ape for the Cairo-lang.
+- [ape-starknet](https://github.com/ApeWorX/ape-starknet) - Ape plugin for the StarkNet networks.
 
 #### Utility
 


### PR DESCRIPTION
[Please describe your pull request here]
Added ape-starknet and ape-cairo plugins 
## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
