### PR TITLE
Add Empiric Network to "Built / Deployed" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@
 - [argent-contracts-starknet](https://github.com/argentlabs/argent-contracts-starknet) -
   [Argent](https://www.argent.xyz/)'s Account contracts
 - [briq](https://github.com/briqNFT/briq-protocol) - NFT building & composability protocol
+- [Empiric Network](https://github.com/42labs/Empiric) - Oracle providing decentralized, transparent and composable data.
 
 #### Templates
 


### PR DESCRIPTION
Added the oracle [Empiric Network](https://empiric.network/) to the "built / deployed" section. Added it to the bottom since there is currently no alphabetic ordering. I can update this PR or make a new one where all entries are sorted if that's preferred.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
