### PR TITLE
Add starknet-jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@
 - [starknet-rs](https://github.com/xJonathanLEI/starknet-rs) - Rust library
 - [starknet-hardhat-plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) -
   A plugin for integrating Starknet tools into Hardhat projects
-- [starknet-jvm](https://github.com/software-mansion/starknet-jvm) - Library for JVM languages (java, kotlin and others)
+- [starknet-jvm](https://github.com/software-mansion/starknet-jvm) - Library for JVM languages (java, kotlin and others).
 - [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts) -
   OpenZeppelin Contracts written in Cairo
 - [cairomate](https://github.com/a5f9t4/cairomate) - Structured, dependable legos for Starknet development. 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [starknet-rs](https://github.com/xJonathanLEI/starknet-rs) - Rust library
 - [starknet-hardhat-plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) -
   A plugin for integrating Starknet tools into Hardhat projects
+- [starknet-jvm](https://github.com/software-mansion/starknet-jvm) - Library for JVM languages (java, kotlin and others)
 - [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts) -
   OpenZeppelin Contracts written in Cairo
 - [cairomate](https://github.com/a5f9t4/cairomate) - Structured, dependable legos for Starknet development. 


### PR DESCRIPTION
Added starknet-jvm, library for jvm languages.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
