### PR TITLE
chore: link to community docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@
 #### Ecosystem
 
 - [StarkNet Ecosystem](https://starknet-ecosystem.com) -
-  A [community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
+  [Community-driven](https://github.com/419Labs/starknet-ecosystem.com) initiative to showcase projects and teams building on StarkNet.
+- [StarkNet Community Docs](https://docs.starknet.io/) - [Community-driven](https://github.com/starknet-community-libs) documentation page.
 
 #### Tutorials
 - [Full-Stack StarkNet](https://github.com/sambarnes/fullstack-starknet) - Tutorials introducing a little bit of everything in a DApp.


### PR DESCRIPTION
Added link to community docs page: https://docs.starknet.io/

[Please describe your pull request here]

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
